### PR TITLE
YOLO-5547: Commercial API Post and Get Future Sheet

### DIFF
--- a/src/Forbury.Integrations/API/v1/Dto/Model/Commercial/Input/Enums/GrowthBasisType.cs
+++ b/src/Forbury.Integrations/API/v1/Dto/Model/Commercial/Input/Enums/GrowthBasisType.cs
@@ -1,8 +1,0 @@
-﻿namespace Forbury.Integrations.API.v1.Dto.Model.Commercial.Input.Enums
-{
-    public enum GrowthBasisType
-    {
-        Net,
-        Gross
-    }
-}

--- a/src/Forbury.Integrations/API/v1/Dto/Model/Commercial/Input/Future/FuturesDto.cs
+++ b/src/Forbury.Integrations/API/v1/Dto/Model/Commercial/Input/Future/FuturesDto.cs
@@ -11,10 +11,8 @@ namespace Forbury.Integrations.API.v1.Dto.Model.Commercial.Input.Future
         public CalendarBasis MarketYearBasis { get; set; }
         [JsonConverter(typeof(StringEnumConverter))]
         public CalendarBasis OutgoingsYearBasis { get; set; }
-        [JsonConverter(typeof(StringEnumConverter))]
-        public CalendarBasis EscalationYearBasis { get; set; }
-        [JsonConverter(typeof(StringEnumConverter))]
-        public GrowthBasisType MarketRentGrowthBasis { get; set; }
+        public string EscalationYearBasis { get; set; }
+        public string MarketRentGrowthBasis { get; set; }
         public decimal? PriorYearCpi { get; set; }
         public bool? DeferOutgoings { get; set; }
         public List<GrowthAssumptionDto> EscalationAssumptions { get; set; }


### PR DESCRIPTION
## Overview
Commercial API Post and Get Future Sheet

- Updated the property type for EscalationYearBasis and MarketRentGrowthBasis from enum to string
- Removed the unused GrowthBasisType enum

